### PR TITLE
Update identity.py(np.int to np.int32)

### DIFF
--- a/TrackEval/trackeval/metrics/identity.py
+++ b/TrackEval/trackeval/metrics/identity.py
@@ -80,9 +80,9 @@ class Identity(_BaseMetric):
         match_rows, match_cols = linear_sum_assignment(fn_mat + fp_mat)
 
         # Accumulate basic statistics
-        res['IDFN'] = fn_mat[match_rows, match_cols].sum().astype(np.int)
-        res['IDFP'] = fp_mat[match_rows, match_cols].sum().astype(np.int)
-        res['IDTP'] = (gt_id_count.sum() - res['IDFN']).astype(np.int)
+        res['IDFN'] = fn_mat[match_rows, match_cols].sum().astype(np.int32)
+        res['IDFP'] = fp_mat[match_rows, match_cols].sum().astype(np.int32)
+        res['IDTP'] = (gt_id_count.sum() - res['IDFN']).astype(np.int32)
 
         # Calculate final ID scores
         res = self._compute_final_fields(res)


### PR DESCRIPTION
Updated np.int to np.int32 due to deprecation in newer numpy versions.